### PR TITLE
Dry run doesn't mark migrated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 composer.lock
 .php_cs.cache
 coverage.clover
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/yaml": "^2.7 || ^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^8.0",
         "friendsofphp/php-cs-fixer": "^2.0",
         "mikey179/vfsstream": "1.*"
     },

--- a/src/AntiMattr/MongoDB/Migrations/Version.php
+++ b/src/AntiMattr/MongoDB/Migrations/Version.php
@@ -199,10 +199,12 @@ class Version
 
             $this->updateStatisticsAfter();
 
-            if ('up' === $direction) {
-                $this->markMigrated($replay);
-            } else {
-                $this->markNotMigrated();
+            if (!$this->configuration->isDryRun()) {
+                if ('up' === $direction) {
+                    $this->markMigrated($replay);
+                } else {
+                    $this->markNotMigrated();
+                }
             }
 
             $this->summarizeStatistics();

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
@@ -10,7 +10,7 @@ class StatisticsTest extends TestCase
     private $collection;
     private $statistics;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->collection = $this->createMock('MongoDB\Collection');
         $this->statistics = new Statistics();

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationTest.php
@@ -10,7 +10,7 @@ class ConfigurationTest extends TestCase
     private $configuration;
     private $connection;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->connection = $this->createMock('MongoDB\Client');
         $this->configuration = new Configuration($this->connection);

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/AbortExceptionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/AbortExceptionTest.php
@@ -8,7 +8,7 @@ class AbortExceptionTest extends TestCase
 {
     private $exception;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->exception = $this->createMock('AntiMattr\MongoDB\Migrations\Exception\AbortException');
     }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/AbstractMigrationsExceptionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/AbstractMigrationsExceptionTest.php
@@ -9,7 +9,7 @@ class AbstractMigrationsExceptionTest extends TestCase
 {
     private $exception;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->exception = new AbstractMigrationsExceptionStub();
     }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/ConfigurationValidationExceptionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/ConfigurationValidationExceptionTest.php
@@ -8,7 +8,7 @@ class ConfigurationValidationExceptionTest extends TestCase
 {
     private $exception;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->exception = $this->createMock('AntiMattr\MongoDB\Migrations\Exception\ConfigurationValidationException');
     }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/DuplicateVersionExceptionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/DuplicateVersionExceptionTest.php
@@ -8,7 +8,7 @@ class DuplicateVersionExceptionTest extends TestCase
 {
     private $exception;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->exception = $this->createMock('AntiMattr\MongoDB\Migrations\Exception\DuplicateVersionException');
     }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/IrreversibleExceptionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/IrreversibleExceptionTest.php
@@ -8,7 +8,7 @@ class IrreversibleExceptionTest extends TestCase
 {
     private $exception;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->exception = $this->createMock('AntiMattr\MongoDB\Migrations\Exception\IrreversibleException');
     }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/NoMigrationsToExecuteExceptionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/NoMigrationsToExecuteExceptionTest.php
@@ -8,7 +8,7 @@ class NoMigrationsToExecuteExceptionTest extends TestCase
 {
     private $exception;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->exception = $this->createMock('AntiMattr\MongoDB\Migrations\Exception\NoMigrationsToExecuteException');
     }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/SkipExceptionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/SkipExceptionTest.php
@@ -8,7 +8,7 @@ class SkipExceptionTest extends TestCase
 {
     private $exception;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->exception = $this->createMock('AntiMattr\MongoDB\Migrations\Exception\SkipException');
     }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/UnknownVersionExceptionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Exception/UnknownVersionExceptionTest.php
@@ -8,7 +8,7 @@ class UnknownVersionExceptionTest extends TestCase
 {
     private $exception;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->exception = $this->createMock('AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException');
     }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/MigrationTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/MigrationTest.php
@@ -11,7 +11,7 @@ class MigrationTest extends TestCase
     private $migration;
     private $outputWriter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configuration = $this->createMock('AntiMattr\MongoDB\Migrations\Configuration\Configuration');
         $this->outputWriter = $this->createMock('AntiMattr\MongoDB\Migrations\OutputWriter');

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/OutputWriterTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/OutputWriterTest.php
@@ -9,7 +9,7 @@ class OutputWriterTest extends TestCase
 {
     private $outputWriter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
         $output = $this->output;

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/GenerateCommandTest.php
@@ -16,7 +16,7 @@ class GenerateCommandTest extends TestCase
     private $output;
     private $config;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->command = new GenerateCommandStub();
         $this->output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
@@ -26,7 +26,7 @@ class StatusCommandTest extends TestCase
      */
     private $outputFormatter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->command = new StatusCommandStub();
         $this->output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/VersionCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/VersionCommandTest.php
@@ -19,7 +19,7 @@ class VersionCommandTest extends TestCase
     private $migration;
     private $version;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->command = new VersionCommandStub();
         $this->output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');


### PR DESCRIPTION
- only mark migrated or unmigrate when dry run is false
- upgrade phpunit to phpunit ^8.0 so that it's usable with php 8.1
- un deprecate test on version test